### PR TITLE
Add MUI hooks to enforce-use-client-mui

### DIFF
--- a/lib/rules/enforce-use-client-mui.js
+++ b/lib/rules/enforce-use-client-mui.js
@@ -26,6 +26,17 @@ module.exports = {
       return false;
     }
 
+    const muiClientHooks = ['useTheme', 'useMediaQuery', 'useColorScheme'];
+
+    function hasMuiHooks(node) {
+      if (node.type === 'ImportDeclaration') {
+        return node.specifiers.some(
+          (specifier) => specifier.type === 'ImportSpecifier' && muiClientHooks.includes(specifier.imported.name)
+        );
+      }
+      return false;
+    }
+
     return {
       Program(programNode) {
         const sourceCode = context.getSourceCode();
@@ -41,8 +52,9 @@ module.exports = {
         if (hasUseClientDirective) return;
 
         const usesMUIComponents = body.some((node) => hasMUIClientComponents(node));
+        const usesMuiHooks = body.some((node) => hasMuiHooks(node));
 
-        if (!usesMUIComponents) return;
+        if (!usesMUIComponents && !usesMuiHooks) return;
 
         if (hasEdgeRuntimeExport(body)) return;
 

--- a/lib/rules/enforce-use-client-mui.js
+++ b/lib/rules/enforce-use-client-mui.js
@@ -58,8 +58,6 @@ module.exports = {
 
         if (hasEdgeRuntimeExport(body)) return;
 
-        if (hasEdgeRuntimeExport) return;
-
         context.report({
           node: programNode,
           messageId: 'enforceUseClient',


### PR DESCRIPTION
MUI hooks also require 'use client'.

It seems like there was a check to `hasEdgeRuntimeExport` which was always true.
Removed that since this must have been a mistake.